### PR TITLE
Ability to format logged queries

### DIFF
--- a/src/duct/database/sql/hikaricp.clj
+++ b/src/duct/database/sql/hikaricp.clj
@@ -18,32 +18,32 @@
 (defn- logged-query [^QueryInfo query-info]
   (let [query  (.getQuery query-info)
         params (query-parameter-lists query-info)]
-    (into [query] (if (= (count params) 1) (first params) params))))
+   (into [query] (if (= (count params) 1) (first params) params))))
 
-(defn- logging-listener [logger]
+(defn- logging-listener [logger query-formatter]
   (reify QueryExecutionListener
     (beforeQuery [_ _ _])
     (afterQuery [_ exec-info query-infos]
       (let [elapsed (.getElapsedTime exec-info)
-            queries (mapv logged-query query-infos)]
+            queries (mapv (comp (or query-formatter identity) logged-query) query-infos)]
         (if (= (count queries) 1)
           (log/log logger :info ::sql/query {:query (first queries), :elapsed elapsed})
           (log/log logger :info ::sql/batch-query {:queries queries, :elapsed elapsed}))))))
 
-(defn- wrap-logger [datasource logger]
+(defn- wrap-logger [datasource logger query-formatter]
   (doto (ProxyDataSource. datasource)
-    (.addListener (logging-listener logger))))
+    (.addListener (logging-listener logger query-formatter))))
 
 (defn- unwrap-logger [^DataSource datasource]
   (.unwrap datasource DataSource))
 
 (defmethod ig/init-key :duct.database.sql/hikaricp
-  [_ {:keys [logger connection-uri jdbc-url] :as options}]
+  [_ {:keys [logger connection-uri jdbc-url log-query-formatter] :as options}]
   (let [datasource (-> (dissoc options :logger)
                        (assoc :jdbc-url (or jdbc-url connection-uri))
                        (hikari-cp/make-datasource))]
     (if logger
-      (-> (sql/->Boundary {:datasource (wrap-logger datasource logger)})
+      (-> (sql/->Boundary {:datasource (wrap-logger datasource logger log-query-formatter)})
           (assoc :unlogged-spec {:datasource datasource}))
       (sql/->Boundary {:datasource datasource}))))
 

--- a/test/duct/database/sql/hikaricp_test.clj
+++ b/test/duct/database/sql/hikaricp_test.clj
@@ -95,3 +95,35 @@
     (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ? AND body = ?" 1 "a"])
            [{:id 1, :body "a"}]))
     (is (empty? @logs))))
+
+(defn log-query-formatter [[query & params]]
+  (into
+    [(str (re-find #"^\w+" query) "...")]
+    params))
+
+(deftest formatted-logging-test
+  (let [logs     (atom [])
+        logger   (->AtomLogger logs)
+        hikaricp (ig/init-key ::sql/hikaricp {:jdbc-url "jdbc:sqlite:" :logger logger :log-query-formatter log-query-formatter})
+        spec     (:spec hikaricp)]
+    (jdbc/execute! spec ["CREATE TABLE foo (id INT, body TEXT)"])
+    (jdbc/db-do-commands spec ["INSERT INTO foo VALUES (1, 'a')"
+                               "INSERT INTO foo VALUES (2, 'b')"])
+    (is (= (jdbc/query spec ["SELECT * FROM foo"])
+           [{:id 1, :body "a"} {:id 2, :body "b"}]))
+    (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ?" 1])
+           [{:id 1, :body "a"}]))
+    (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ? AND body = ?" 1 "a"])
+           [{:id 1, :body "a"}]))
+    (is (every? nat-int? (map elapsed @logs)))
+    (is (= (map remove-elapsed @logs)
+           [[:info ::sql/query {:query ["CREATE..."]}]
+            [:info ::sql/batch-query {:queries [["INSERT..."]
+                                                ["INSERT..."]]}]
+            [:info ::sql/query {:query ["SELECT..."]}]
+            [:info ::sql/query {:query ["SELECT..." 1]}]
+            [:info ::sql/query
+             {:query ["SELECT..." 1 "a"]}]]))
+    (is (not (.isClosed (unwrap-logger (:datasource spec)))))
+    (ig/halt-key! ::sql/hikaricp hikaricp)
+    (is (.isClosed (unwrap-logger (:datasource spec))))))

--- a/test/duct/database/sql/hikaricp_test.clj
+++ b/test/duct/database/sql/hikaricp_test.clj
@@ -79,3 +79,19 @@
     (is (not (.isClosed (unwrap-logger (:datasource spec)))))
     (ig/halt-key! ::sql/hikaricp hikaricp)
     (is (.isClosed (unwrap-logger (:datasource spec))))))
+
+(deftest unlogged-test
+  (let [logs     (atom [])
+        logger   (->AtomLogger logs)
+        hikaricp (ig/init-key ::sql/hikaricp {:jdbc-url "jdbc:sqlite:" :logger logger})
+        spec     (:unlogged-spec hikaricp)]
+    (jdbc/execute! spec ["CREATE TABLE foo (id INT, body TEXT)"])
+    (jdbc/db-do-commands spec ["INSERT INTO foo VALUES (1, 'a')"
+                               "INSERT INTO foo VALUES (2, 'b')"])
+    (is (= (jdbc/query spec ["SELECT * FROM foo"])
+           [{:id 1, :body "a"} {:id 2, :body "b"}]))
+    (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ?" 1])
+           [{:id 1, :body "a"}]))
+    (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ? AND body = ?" 1 "a"])
+           [{:id 1, :body "a"}]))
+    (is (empty? @logs))))


### PR DESCRIPTION
Adds an optional key `:log-query-formatter` to the component, which takes a function `(fn [query] ...)` that gets passed each query before it gets logged, for allowing custom formatting of the logged query. This does not impact the execution of the query, only how it gets logged.

As briefly discussed in #3

I'm unsure of the key name and whether it should accept a vector of all queries, or each individual query like now. Feedback welcome.