### PR TITLE
Add logging for state changes

### DIFF
--- a/test/duct/database/sql/hikaricp_test.clj
+++ b/test/duct/database/sql/hikaricp_test.clj
@@ -67,9 +67,10 @@
            [{:id 1, :body "a"}]))
     (is (= (jdbc/query spec ["SELECT * FROM foo WHERE id = ? AND body = ?" 1 "a"])
            [{:id 1, :body "a"}]))
-    (is (every? nat-int? (map elapsed @logs)))
+    (is (every? nat-int? (rest (map elapsed @logs))))
     (is (= (map remove-elapsed @logs)
-           [[:info ::sql/query {:query ["CREATE TABLE foo (id INT, body TEXT)"]}]
+           [[:report :duct.database.sql.hikaricp/initializing nil]
+            [:info ::sql/query {:query ["CREATE TABLE foo (id INT, body TEXT)"]}]
             [:info ::sql/batch-query {:queries [["INSERT INTO foo VALUES (1, 'a')"]
                                                 ["INSERT INTO foo VALUES (2, 'b')"]]}]
             [:info ::sql/query {:query ["SELECT * FROM foo"]}]


### PR DESCRIPTION
As discussed in https://github.com/duct-framework/database.sql.hikaricp/pull/7#issuecomment-1011208294

- Logger now attached to the boundary.
- Logs now log nil instead of url.
- :report is still used as [server.http.jetty](https://github.com/duct-framework/server.http.jetty/blob/ada870967143e279236cbd41e8a842ff31898c45/src/duct/server/http/jetty.clj#L21) (not sure if another level is best for this case.)
