### PR TITLE
Make jdbc-url and connection-uri optional

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "https://github.com/duct-framework/database.sql.hikaricp"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.0"]
                  [duct/core "0.8.0"]
                  [duct/database.sql "0.1.0"]
                  [duct/logger "0.3.0"]
-                 [hikari-cp "2.13.0"]
+                 [hikari-cp "3.0.1"]
                  [integrant "0.8.0"]
                  [net.ttddyy/datasource-proxy "1.7"]]
   :profiles

--- a/src/duct/database/sql/hikaricp.clj
+++ b/src/duct/database/sql/hikaricp.clj
@@ -41,7 +41,8 @@
   [_ {:keys [logger connection-uri jdbc-url] :as options}]
   (sql/->Boundary {:datasource
                    (-> (dissoc options :logger)
-                       (assoc :jdbc-url (or jdbc-url connection-uri))
+                       (cond-> (and (nil? jdbc-url) connection-uri)
+                         (assoc :jdbc-url connection-uri))
                        (hikari-cp/make-datasource)
                        (cond-> logger (wrap-logger logger)))}))
 

--- a/test/duct/database/sql/hikaricp_test.clj
+++ b/test/duct/database/sql/hikaricp_test.clj
@@ -31,6 +31,20 @@
         (is (instance? javax.sql.DataSource datasource))
         (is (not (.isClosed datasource)))
         (ig/halt! system)
+        (is (.isClosed datasource)))))
+
+  (testing "independent connection options"
+    (let [config   {::sql/hikaricp {:adapter "sqlite"
+                                    :database-name ""
+                                    :username ""
+                                    :password ""}}
+          system   (ig/init config)
+          hikaricp (::sql/hikaricp system)]
+      (is (instance? duct.database.sql.Boundary hikaricp))
+      (let [datasource (-> hikaricp :spec :datasource)]
+        (is (instance? javax.sql.DataSource datasource))
+        (is (not (.isClosed datasource)))
+        (ig/halt! system)
         (is (.isClosed datasource))))))
 
 (deftest execute-test


### PR DESCRIPTION
One important caveat for this pull request, from https://github.com/tomekw/hikari-cp#installation:

> hikari-cp version 3.x targets Clojure 1.11. Version 2.14.3 was the last release for Clojure 1.9. Version 1.8.3 was the last release for Clojure 1.8.
> Note that hikari-cp requires Java 11 or newer. Version 2.14.3 was the last release for Java 8.